### PR TITLE
feat: use env list for some settings

### DIFF
--- a/mousetube_api/settings.py
+++ b/mousetube_api/settings.py
@@ -46,20 +46,17 @@ DEBUG = env("DEBUG", default=False)
 
 # CORS_ORIGIN_ALLOW_ALL = True
 
-CORS_ALLOWED_ORIGINS = [
-    "https://mousetube.france-bioinformatique.fr",
+CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=[
     "http://localhost:3000",
     "http://127.0.0.1:3000",
     "https://mousetube.local",
-    "http://127.0.0.1:8001",
-]
-CSRF_TRUSTED_ORIGINS = [
-    "https://mousetube.france-bioinformatique.fr",
+])
+
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[
     "http://localhost:3000",
     "http://127.0.0.1:3000",
     "https://mousetube.local",
-    "http://127.0.0.1:8001",
-]
+])
 CORS_ALLOW_CREDENTIALS = True
 X_FRAME_OPTIONS = "ALLOW-FROM http://127.0.0.1:8001"
 
@@ -67,6 +64,8 @@ SECURE_SSL_REDIRECT = not DEBUG
 SESSION_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_SECURE = not DEBUG
 
+USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST", default=False)
+SECURE_PROXY_SSL_HEADER = env.tuple("SECURE_PROXY_SSL_HEADER", default=("HTTP_X_FORWARDED_PROTO", "https"))
 
 # Application definition
 
@@ -177,7 +176,6 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media/")
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 APPEND_SLASH = True
 
 REST_FRAMEWORK = {

--- a/mousetube_api/settings.py
+++ b/mousetube_api/settings.py
@@ -46,17 +46,23 @@ DEBUG = env("DEBUG", default=False)
 
 # CORS_ORIGIN_ALLOW_ALL = True
 
-CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=[
-    "http://localhost:3000",
-    "http://127.0.0.1:3000",
-    "https://mousetube.local",
-])
+CORS_ALLOWED_ORIGINS = env.list(
+    "CORS_ALLOWED_ORIGINS",
+    default=[
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "https://mousetube.local",
+    ],
+)
 
-CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[
-    "http://localhost:3000",
-    "http://127.0.0.1:3000",
-    "https://mousetube.local",
-])
+CSRF_TRUSTED_ORIGINS = env.list(
+    "CSRF_TRUSTED_ORIGINS",
+    default=[
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "https://mousetube.local",
+    ],
+)
 CORS_ALLOW_CREDENTIALS = True
 X_FRAME_OPTIONS = "ALLOW-FROM http://127.0.0.1:8001"
 
@@ -65,7 +71,9 @@ SESSION_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_SECURE = not DEBUG
 
 USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST", default=False)
-SECURE_PROXY_SSL_HEADER = env.tuple("SECURE_PROXY_SSL_HEADER", default=("HTTP_X_FORWARDED_PROTO", "https"))
+SECURE_PROXY_SSL_HEADER = env.tuple(
+    "SECURE_PROXY_SSL_HEADER", default=("HTTP_X_FORWARDED_PROTO", "https")
+)
 
 # Application definition
 


### PR DESCRIPTION
- [x] use env list for CORS_ALLOWED_ORIGINS, CSRF_TRUSTED_ORIGINS, USE_X_FORWARDED_HOST, SECURE_PROXY_SSL_HEADER