### PR TITLE
feat: add nginx swagger access and update django to 5.2.9

### DIFF
--- a/nginx/conf.d/default.conf.template
+++ b/nginx/conf.d/default.conf.template
@@ -54,4 +54,18 @@ server {
         expires 30d;
         add_header Cache-Control "public";
     }
+
+    # Django Swagger
+    location /swagger/ {
+    proxy_pass http://web:8000/swagger/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Django schema
+    location /schema/ {
+        proxy_pass http://web:8000/schema/;
+        proxy_set_header Host $host;
+    }
 }

--- a/nginx/conf.d/default.conf.template
+++ b/nginx/conf.d/default.conf.template
@@ -57,10 +57,10 @@ server {
 
     # Django Swagger
     location /swagger/ {
-    proxy_pass http://web:8000/swagger/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://web:8000/swagger/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     # Django schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Laurent Bouri", email = "laurent.bouri@igbmc.fr" },
 ]
 dependencies = [
-    "Django==5.2.8",
+    "Django==5.2.9",
     "djangorestframework==3.16.0",
     "djoser==2.3.1",
     "django-cors-headers==4.7.0",


### PR DESCRIPTION
This PR adds full reverse-proxy support for Swagger UI and the OpenAPI schema through Nginx.
It ensures that the Django API documentation is correctly accessible when mouseTube is deployed.

🔧 Changes

Added Nginx routing for:

  /swagger/ → Django Swagger UI
  
  /schema/ → OpenAPI schema endpoint